### PR TITLE
Fix for random moves in Firefox

### DIFF
--- a/lib/Board.mjs
+++ b/lib/Board.mjs
@@ -819,7 +819,7 @@ export default class Board {
         }
 
         scoreTable.sort((previous, next) => {
-            return previous.score < next.score ? 0 : -1
+            return previous.score < next.score ? 1 : previous.score > next.score ? -1 : 0
         })
         return scoreTable
     }


### PR DESCRIPTION
The array sort function wasn't working correctly in Firefox.  Returning 1 when previous.score < next.score fixes the issue.  

Thanks, Josef, for creating js-chess-engine.

-Adam