### PR TITLE
#29 possibility to disable checks and checkmate

### DIFF
--- a/lib/Board.mjs
+++ b/lib/Board.mjs
@@ -848,12 +848,12 @@ export default class Board {
         return new Board(testConfiguration)
     }
 
-    testMoveScores (playingPlayerColor, level, capture, initialScore, move, depth = 1, ignoreCheck = false) {
+    testMoveScores (playingPlayerColor, level, capture, initialScore, move, depth = 1, ignoreCheckValidation = false) {
         let nextMoves = null
         if (depth < AI_DEPTH_BY_LEVEL.EXTENDED[level] && this.hasPlayingPlayerCheck()) {
-            nextMoves = this.getMoves(this.getPlayingColor(), null, ignoreCheck)
+            nextMoves = this.getMoves(this.getPlayingColor(), null, ignoreCheckValidation)
         } else if (depth < AI_DEPTH_BY_LEVEL.BASE[level] || (capture && depth < AI_DEPTH_BY_LEVEL.EXTENDED[level])) {
-            nextMoves = this.getMoves(this.getPlayingColor(), 5, ignoreCheck)
+            nextMoves = this.getMoves(this.getPlayingColor(), 5, ignoreCheckValidation)
         }
 
         if (this.configuration.isFinished) {

--- a/lib/Board.mjs
+++ b/lib/Board.mjs
@@ -258,7 +258,7 @@ export default class Board {
         return pieceValue
     }
 
-    getMoves (color = this.getPlayingColor(), movablePiecesRequiredToSkipTest = null) {
+    getMoves (color = this.getPlayingColor(), movablePiecesRequiredToSkipTest = null, ignoreCheckValidation = false) {
         const allMoves = {}
         let movablePiecesCount = 0
         for (const location in this.configuration.pieces) {
@@ -294,6 +294,7 @@ export default class Board {
                 const testBoard = new Board(testConfiguration)
                 testBoard.move(from, to)
                 if (
+                    ignoreCheckValidation ||
                     (this.isPlayingWhite() && !testBoard.isAttackingKing(COLORS.BLACK)) ||
                     (this.isPlayingBlack() && !testBoard.isAttackingKing(COLORS.WHITE))
                 ) {

--- a/lib/Board.mjs
+++ b/lib/Board.mjs
@@ -788,12 +788,12 @@ export default class Board {
         }
     }
 
-    calculateAiMove (level) {
-        const scores = this.calculateAiMoves(level)
+    calculateAiMove (level, ignoreCheck = false) {
+        const scores = this.calculateAiMoves(level, ignoreCheck)
         return scores[0]
     }
 
-    calculateAiMoves (level) {
+    calculateAiMoves (level, ignoreCheck = false) {
         level = parseInt(level)
         if (!AI_LEVELS.includes(level)) {
             throw new Error(`Invalid level ${level}. You can choose ${AI_LEVELS.join(',')}`)
@@ -803,7 +803,7 @@ export default class Board {
         }
         const scoreTable = []
         const initialScore = this.calculateScore(this.getPlayingColor())
-        const moves = this.getMoves()
+        const moves = this.getMoves(this.getPlayingColor(), null, ignoreCheck)
         for (const from in moves) {
             moves[from].map(to => {
                 const testBoard = this.getTestBoard()

--- a/lib/Board.mjs
+++ b/lib/Board.mjs
@@ -39,7 +39,7 @@ const SCORE = {
 const PIECE_VALUE_MULTIPLIER = 10
 
 export default class Board {
-    constructor (configuration = JSON.parse(JSON.stringify(NEW_GAME_BOARD_CONFIG))) {
+    constructor(configuration = JSON.parse(JSON.stringify(NEW_GAME_BOARD_CONFIG))) {
         if (typeof configuration === 'object') {
             this.configuration = Object.assign({}, NEW_GAME_SETTINGS, configuration)
         } else if (typeof configuration === 'string') {
@@ -58,7 +58,7 @@ export default class Board {
         this.history = []
     }
 
-    getAttackingFields (color = this.getPlayingColor()) {
+    getAttackingFields(color = this.getPlayingColor()) {
         let attackingFields = []
         for (const location in this.configuration.pieces) {
             const piece = this.getPiece(location)
@@ -69,7 +69,7 @@ export default class Board {
         return attackingFields
     }
 
-    isAttackingKing (color = this.getPlayingColor()) {
+    isAttackingKing(color = this.getPlayingColor()) {
         let kingLocation = null
         for (const location in this.configuration.pieces) {
             const piece = this.getPiece(location)
@@ -82,7 +82,7 @@ export default class Board {
         return this.isPieceUnderAttack(kingLocation)
     }
 
-    isPieceUnderAttack (pieceLocation) {
+    isPieceUnderAttack(pieceLocation) {
         const playerColor = this.getPieceOnLocationColor(pieceLocation)
         const enemyColor = this.getEnemyColor(playerColor)
         let isUnderAttack = false
@@ -235,15 +235,15 @@ export default class Board {
         return isUnderAttack
     }
 
-    hasPlayingPlayerCheck () {
+    hasPlayingPlayerCheck() {
         return this.isAttackingKing(this.getNonPlayingColor())
     }
 
-    hasNonPlayingPlayerCheck () {
+    hasNonPlayingPlayerCheck() {
         return this.isAttackingKing(this.getPlayingColor())
     }
 
-    getLowestValuePieceAttackingLocation (location, color = this.getPlayingColor()) {
+    getLowestValuePieceAttackingLocation(location, color = this.getPlayingColor()) {
         let pieceValue = null
         for (const field in this.configuration.pieces) {
             const piece = this.getPiece(field)
@@ -258,7 +258,7 @@ export default class Board {
         return pieceValue
     }
 
-    getMoves (color = this.getPlayingColor(), movablePiecesRequiredToSkipTest = null, ignoreCheckValidation = false) {
+    getMoves(color = this.getPlayingColor(), movablePiecesRequiredToSkipTest = null, ignoreCheckValidation = false) {
         const allMoves = {}
         let movablePiecesCount = 0
         for (const location in this.configuration.pieces) {
@@ -316,7 +316,7 @@ export default class Board {
         return moves
     }
 
-    isLeftCastlingPossible (enemyAttackingFields) {
+    isLeftCastlingPossible(enemyAttackingFields) {
         if (this.isPlayingWhite() && !this.configuration.castling.whiteLong) return false
         if (this.isPlayingBlack() && !this.configuration.castling.blackLong) return false
 
@@ -337,7 +337,7 @@ export default class Board {
         return true
     }
 
-    isRightCastlingPossible (enemyAttackingFields) {
+    isRightCastlingPossible(enemyAttackingFields) {
         if (this.isPlayingWhite() && !this.configuration.castling.whiteShort) return false
         if (this.isPlayingBlack() && !this.configuration.castling.blackShort) return false
 
@@ -357,7 +357,7 @@ export default class Board {
         return true
     }
 
-    getPieceMoves (piece, location) {
+    getPieceMoves(piece, location) {
         if (this.isPawn(piece)) return this.getPawnMoves(piece, location)
         if (this.isKnight(piece)) return this.getKnightMoves(piece, location)
         if (this.isRook(piece)) return this.getRookMoves(piece, location)
@@ -367,31 +367,31 @@ export default class Board {
         return []
     }
 
-    isPawn (piece) {
+    isPawn(piece) {
         return piece.toUpperCase() === 'P'
     }
 
-    isKnight (piece) {
+    isKnight(piece) {
         return piece.toUpperCase() === 'N'
     }
 
-    isRook (piece) {
+    isRook(piece) {
         return piece.toUpperCase() === 'R'
     }
 
-    isBishop (piece) {
+    isBishop(piece) {
         return piece.toUpperCase() === 'B'
     }
 
-    isQueen (piece) {
+    isQueen(piece) {
         return piece.toUpperCase() === 'Q'
     }
 
-    isKing (piece) {
+    isKing(piece) {
         return piece.toUpperCase() === 'K'
     }
 
-    getPawnMoves (piece, location) {
+    getPawnMoves(piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
         let move = upByColor(location, color)
@@ -414,7 +414,7 @@ export default class Board {
             moves.push(move)
         }
 
-        function isInStartLine (color, location) {
+        function isInStartLine(color, location) {
             if (color === COLORS.WHITE && location[1] === '2') {
                 return true
             }
@@ -427,7 +427,7 @@ export default class Board {
         return moves
     }
 
-    getKnightMoves (piece, location) {
+    getKnightMoves(piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
 
@@ -474,7 +474,7 @@ export default class Board {
         return moves
     }
 
-    getRookMoves (piece, location) {
+    getRookMoves(piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
 
@@ -521,7 +521,7 @@ export default class Board {
         return moves
     }
 
-    getBishopMoves (piece, location) {
+    getBishopMoves(piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
 
@@ -568,7 +568,7 @@ export default class Board {
         return moves
     }
 
-    getQueenMoves (piece, location) {
+    getQueenMoves(piece, location) {
         const moves = [
             ...this.getRookMoves(piece, location),
             ...this.getBishopMoves(piece, location),
@@ -576,7 +576,7 @@ export default class Board {
         return moves
     }
 
-    getKingMoves (piece, location) {
+    getKingMoves(piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
 
@@ -631,23 +631,23 @@ export default class Board {
         return moves
     }
 
-    getPieceColor (piece) {
+    getPieceColor(piece) {
         if (piece.toUpperCase() === piece) return COLORS.WHITE
         return COLORS.BLACK
     }
 
-    getPieceOnLocationColor (location) {
+    getPieceOnLocationColor(location) {
         const piece = this.getPiece(location)
         if (!piece) return null
         if (piece.toUpperCase() === piece) return COLORS.WHITE
         return COLORS.BLACK
     }
 
-    getPiece (location) {
+    getPiece(location) {
         return this.configuration.pieces[location]
     }
 
-    setPiece (location, piece) {
+    setPiece(location, piece) {
         if (!isPieceValid(piece)) {
             throw new Error(`Invalid piece ${piece}`)
         }
@@ -659,7 +659,7 @@ export default class Board {
         this.configuration.pieces[location.toUpperCase()] = piece
     }
 
-    removePiece (location) {
+    removePiece(location) {
         if (!isLocationValid(location)) {
             throw new Error(`Invalid location ${location}`)
         }
@@ -667,7 +667,7 @@ export default class Board {
         delete this.configuration.pieces[location.toUpperCase()]
     }
 
-    isEmpty (location) {
+    isEmpty(location) {
         if (!isLocationValid(location)) {
             throw new Error(`Invalid location ${location}`)
         }
@@ -675,31 +675,31 @@ export default class Board {
         return !this.configuration.pieces[location.toUpperCase()]
     }
 
-    getEnemyColor (playerColor) {
+    getEnemyColor(playerColor) {
         return playerColor === COLORS.WHITE ? COLORS.BLACK : COLORS.WHITE
     }
 
-    getPlayingColor () {
+    getPlayingColor() {
         return this.configuration.turn
     }
 
-    getNonPlayingColor () {
+    getNonPlayingColor() {
         return this.isPlayingWhite() ? COLORS.BLACK : COLORS.WHITE
     }
 
-    isPlayingWhite () {
+    isPlayingWhite() {
         return this.configuration.turn === COLORS.WHITE
     }
 
-    isPlayingBlack () {
+    isPlayingBlack() {
         return this.configuration.turn === COLORS.BLACK
     }
 
-    addMoveToHistory (from, to) {
+    addMoveToHistory(from, to) {
         this.history.push({ from, to, configuration: JSON.parse(JSON.stringify(this.configuration)) })
     }
 
-    move (from, to) {
+    move(from, to) {
         // Move logic
         const chessmanFrom = this.getPiece(from)
         const chessmanTo = this.getPiece(to)
@@ -773,7 +773,7 @@ export default class Board {
         }
     }
 
-    exportJson () {
+    exportJson() {
         return {
             moves: this.getMoves(),
             pieces: this.configuration.pieces,
@@ -788,12 +788,12 @@ export default class Board {
         }
     }
 
-    calculateAiMove (level, ignoreCheck = false) {
-        const scores = this.calculateAiMoves(level, ignoreCheck)
+    calculateAiMove(level, ignoreCheckValidation = false) {
+        const scores = this.calculateAiMoves(level, ignoreCheckValidation)
         return scores[0]
     }
 
-    calculateAiMoves (level, ignoreCheck = false) {
+    calculateAiMoves(level, ignoreCheckValidation = false) {
         level = parseInt(level)
         if (!AI_LEVELS.includes(level)) {
             throw new Error(`Invalid level ${level}. You can choose ${AI_LEVELS.join(',')}`)
@@ -803,7 +803,7 @@ export default class Board {
         }
         const scoreTable = []
         const initialScore = this.calculateScore(this.getPlayingColor())
-        const moves = this.getMoves(this.getPlayingColor(), null, ignoreCheck)
+        const moves = this.getMoves(this.getPlayingColor(), null, ignoreCheckValidation)
         for (const from in moves) {
             moves[from].map(to => {
                 const testBoard = this.getTestBoard()
@@ -825,11 +825,11 @@ export default class Board {
         return scoreTable
     }
 
-    shouldIncreaseLevel () {
+    shouldIncreaseLevel() {
         return this.getIngamePiecesValue() < 50
     }
 
-    getIngamePiecesValue () {
+    getIngamePiecesValue() {
         let scoreIndex = 0
         for (const location in this.configuration.pieces) {
             const piece = this.getPiece(location)
@@ -838,7 +838,7 @@ export default class Board {
         return scoreIndex
     }
 
-    getTestBoard () {
+    getTestBoard() {
         const testConfiguration = {
             pieces: Object.assign({}, this.configuration.pieces),
             castling: Object.assign({}, this.configuration.castling),
@@ -848,7 +848,7 @@ export default class Board {
         return new Board(testConfiguration)
     }
 
-    testMoveScores (playingPlayerColor, level, capture, initialScore, move, depth = 1) {
+    testMoveScores(playingPlayerColor, level, capture, initialScore, move, depth = 1) {
         let nextMoves = null
         if (depth < AI_DEPTH_BY_LEVEL.EXTENDED[level] && this.hasPlayingPlayerCheck()) {
             nextMoves = this.getMoves(this.getPlayingColor())
@@ -897,7 +897,7 @@ export default class Board {
         return { score: bestScore, max: false }
     }
 
-    calculateScoreByPiecesLocation (player = this.getPlayingColor()) {
+    calculateScoreByPiecesLocation(player = this.getPlayingColor()) {
         const columnMapping = { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7 }
         const scoreMultiplier = 0.5
         let score = 0
@@ -911,7 +911,7 @@ export default class Board {
         return score
     }
 
-    calculateScore (playerColor = this.getPlayingColor()) {
+    calculateScore(playerColor = this.getPlayingColor()) {
         let scoreIndex = 0
 
         if (this.configuration.checkMate) {

--- a/lib/Board.mjs
+++ b/lib/Board.mjs
@@ -39,7 +39,7 @@ const SCORE = {
 const PIECE_VALUE_MULTIPLIER = 10
 
 export default class Board {
-    constructor(configuration = JSON.parse(JSON.stringify(NEW_GAME_BOARD_CONFIG))) {
+    constructor (configuration = JSON.parse(JSON.stringify(NEW_GAME_BOARD_CONFIG))) {
         if (typeof configuration === 'object') {
             this.configuration = Object.assign({}, NEW_GAME_SETTINGS, configuration)
         } else if (typeof configuration === 'string') {
@@ -58,7 +58,7 @@ export default class Board {
         this.history = []
     }
 
-    getAttackingFields(color = this.getPlayingColor()) {
+    getAttackingFields (color = this.getPlayingColor()) {
         let attackingFields = []
         for (const location in this.configuration.pieces) {
             const piece = this.getPiece(location)
@@ -69,7 +69,7 @@ export default class Board {
         return attackingFields
     }
 
-    isAttackingKing(color = this.getPlayingColor()) {
+    isAttackingKing (color = this.getPlayingColor()) {
         let kingLocation = null
         for (const location in this.configuration.pieces) {
             const piece = this.getPiece(location)
@@ -82,7 +82,7 @@ export default class Board {
         return this.isPieceUnderAttack(kingLocation)
     }
 
-    isPieceUnderAttack(pieceLocation) {
+    isPieceUnderAttack (pieceLocation) {
         const playerColor = this.getPieceOnLocationColor(pieceLocation)
         const enemyColor = this.getEnemyColor(playerColor)
         let isUnderAttack = false
@@ -235,15 +235,15 @@ export default class Board {
         return isUnderAttack
     }
 
-    hasPlayingPlayerCheck() {
+    hasPlayingPlayerCheck () {
         return this.isAttackingKing(this.getNonPlayingColor())
     }
 
-    hasNonPlayingPlayerCheck() {
+    hasNonPlayingPlayerCheck () {
         return this.isAttackingKing(this.getPlayingColor())
     }
 
-    getLowestValuePieceAttackingLocation(location, color = this.getPlayingColor()) {
+    getLowestValuePieceAttackingLocation (location, color = this.getPlayingColor()) {
         let pieceValue = null
         for (const field in this.configuration.pieces) {
             const piece = this.getPiece(field)
@@ -258,7 +258,7 @@ export default class Board {
         return pieceValue
     }
 
-    getMoves(color = this.getPlayingColor(), movablePiecesRequiredToSkipTest = null, ignoreCheckValidation = false) {
+    getMoves (color = this.getPlayingColor(), movablePiecesRequiredToSkipTest = null, ignoreCheckValidation = false) {
         const allMoves = {}
         let movablePiecesCount = 0
         for (const location in this.configuration.pieces) {
@@ -316,7 +316,7 @@ export default class Board {
         return moves
     }
 
-    isLeftCastlingPossible(enemyAttackingFields) {
+    isLeftCastlingPossible (enemyAttackingFields) {
         if (this.isPlayingWhite() && !this.configuration.castling.whiteLong) return false
         if (this.isPlayingBlack() && !this.configuration.castling.blackLong) return false
 
@@ -337,7 +337,7 @@ export default class Board {
         return true
     }
 
-    isRightCastlingPossible(enemyAttackingFields) {
+    isRightCastlingPossible (enemyAttackingFields) {
         if (this.isPlayingWhite() && !this.configuration.castling.whiteShort) return false
         if (this.isPlayingBlack() && !this.configuration.castling.blackShort) return false
 
@@ -357,7 +357,7 @@ export default class Board {
         return true
     }
 
-    getPieceMoves(piece, location) {
+    getPieceMoves (piece, location) {
         if (this.isPawn(piece)) return this.getPawnMoves(piece, location)
         if (this.isKnight(piece)) return this.getKnightMoves(piece, location)
         if (this.isRook(piece)) return this.getRookMoves(piece, location)
@@ -367,31 +367,31 @@ export default class Board {
         return []
     }
 
-    isPawn(piece) {
+    isPawn (piece) {
         return piece.toUpperCase() === 'P'
     }
 
-    isKnight(piece) {
+    isKnight (piece) {
         return piece.toUpperCase() === 'N'
     }
 
-    isRook(piece) {
+    isRook (piece) {
         return piece.toUpperCase() === 'R'
     }
 
-    isBishop(piece) {
+    isBishop (piece) {
         return piece.toUpperCase() === 'B'
     }
 
-    isQueen(piece) {
+    isQueen (piece) {
         return piece.toUpperCase() === 'Q'
     }
 
-    isKing(piece) {
+    isKing (piece) {
         return piece.toUpperCase() === 'K'
     }
 
-    getPawnMoves(piece, location) {
+    getPawnMoves (piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
         let move = upByColor(location, color)
@@ -414,7 +414,7 @@ export default class Board {
             moves.push(move)
         }
 
-        function isInStartLine(color, location) {
+        function isInStartLine (color, location) {
             if (color === COLORS.WHITE && location[1] === '2') {
                 return true
             }
@@ -427,7 +427,7 @@ export default class Board {
         return moves
     }
 
-    getKnightMoves(piece, location) {
+    getKnightMoves (piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
 
@@ -474,7 +474,7 @@ export default class Board {
         return moves
     }
 
-    getRookMoves(piece, location) {
+    getRookMoves (piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
 
@@ -521,7 +521,7 @@ export default class Board {
         return moves
     }
 
-    getBishopMoves(piece, location) {
+    getBishopMoves (piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
 
@@ -568,7 +568,7 @@ export default class Board {
         return moves
     }
 
-    getQueenMoves(piece, location) {
+    getQueenMoves (piece, location) {
         const moves = [
             ...this.getRookMoves(piece, location),
             ...this.getBishopMoves(piece, location),
@@ -576,7 +576,7 @@ export default class Board {
         return moves
     }
 
-    getKingMoves(piece, location) {
+    getKingMoves (piece, location) {
         const moves = []
         const color = this.getPieceColor(piece)
 
@@ -631,23 +631,23 @@ export default class Board {
         return moves
     }
 
-    getPieceColor(piece) {
+    getPieceColor (piece) {
         if (piece.toUpperCase() === piece) return COLORS.WHITE
         return COLORS.BLACK
     }
 
-    getPieceOnLocationColor(location) {
+    getPieceOnLocationColor (location) {
         const piece = this.getPiece(location)
         if (!piece) return null
         if (piece.toUpperCase() === piece) return COLORS.WHITE
         return COLORS.BLACK
     }
 
-    getPiece(location) {
+    getPiece (location) {
         return this.configuration.pieces[location]
     }
 
-    setPiece(location, piece) {
+    setPiece (location, piece) {
         if (!isPieceValid(piece)) {
             throw new Error(`Invalid piece ${piece}`)
         }
@@ -659,7 +659,7 @@ export default class Board {
         this.configuration.pieces[location.toUpperCase()] = piece
     }
 
-    removePiece(location) {
+    removePiece (location) {
         if (!isLocationValid(location)) {
             throw new Error(`Invalid location ${location}`)
         }
@@ -667,7 +667,7 @@ export default class Board {
         delete this.configuration.pieces[location.toUpperCase()]
     }
 
-    isEmpty(location) {
+    isEmpty (location) {
         if (!isLocationValid(location)) {
             throw new Error(`Invalid location ${location}`)
         }
@@ -675,31 +675,31 @@ export default class Board {
         return !this.configuration.pieces[location.toUpperCase()]
     }
 
-    getEnemyColor(playerColor) {
+    getEnemyColor (playerColor) {
         return playerColor === COLORS.WHITE ? COLORS.BLACK : COLORS.WHITE
     }
 
-    getPlayingColor() {
+    getPlayingColor () {
         return this.configuration.turn
     }
 
-    getNonPlayingColor() {
+    getNonPlayingColor () {
         return this.isPlayingWhite() ? COLORS.BLACK : COLORS.WHITE
     }
 
-    isPlayingWhite() {
+    isPlayingWhite () {
         return this.configuration.turn === COLORS.WHITE
     }
 
-    isPlayingBlack() {
+    isPlayingBlack () {
         return this.configuration.turn === COLORS.BLACK
     }
 
-    addMoveToHistory(from, to) {
+    addMoveToHistory (from, to) {
         this.history.push({ from, to, configuration: JSON.parse(JSON.stringify(this.configuration)) })
     }
 
-    move(from, to) {
+    move (from, to) {
         // Move logic
         const chessmanFrom = this.getPiece(from)
         const chessmanTo = this.getPiece(to)
@@ -773,7 +773,7 @@ export default class Board {
         }
     }
 
-    exportJson() {
+    exportJson () {
         return {
             moves: this.getMoves(),
             pieces: this.configuration.pieces,
@@ -788,12 +788,12 @@ export default class Board {
         }
     }
 
-    calculateAiMove(level, ignoreCheckValidation = false) {
+    calculateAiMove (level, ignoreCheckValidation = false) {
         const scores = this.calculateAiMoves(level, ignoreCheckValidation)
         return scores[0]
     }
 
-    calculateAiMoves(level, ignoreCheckValidation = false) {
+    calculateAiMoves (level, ignoreCheckValidation = false) {
         level = parseInt(level)
         if (!AI_LEVELS.includes(level)) {
             throw new Error(`Invalid level ${level}. You can choose ${AI_LEVELS.join(',')}`)
@@ -825,11 +825,11 @@ export default class Board {
         return scoreTable
     }
 
-    shouldIncreaseLevel() {
+    shouldIncreaseLevel () {
         return this.getIngamePiecesValue() < 50
     }
 
-    getIngamePiecesValue() {
+    getIngamePiecesValue () {
         let scoreIndex = 0
         for (const location in this.configuration.pieces) {
             const piece = this.getPiece(location)
@@ -838,7 +838,7 @@ export default class Board {
         return scoreIndex
     }
 
-    getTestBoard() {
+    getTestBoard () {
         const testConfiguration = {
             pieces: Object.assign({}, this.configuration.pieces),
             castling: Object.assign({}, this.configuration.castling),
@@ -848,12 +848,12 @@ export default class Board {
         return new Board(testConfiguration)
     }
 
-    testMoveScores(playingPlayerColor, level, capture, initialScore, move, depth = 1) {
+    testMoveScores (playingPlayerColor, level, capture, initialScore, move, depth = 1, ignoreCheck = false) {
         let nextMoves = null
         if (depth < AI_DEPTH_BY_LEVEL.EXTENDED[level] && this.hasPlayingPlayerCheck()) {
-            nextMoves = this.getMoves(this.getPlayingColor())
+            nextMoves = this.getMoves(this.getPlayingColor(), null, ignoreCheck)
         } else if (depth < AI_DEPTH_BY_LEVEL.BASE[level] || (capture && depth < AI_DEPTH_BY_LEVEL.EXTENDED[level])) {
-            nextMoves = this.getMoves(this.getPlayingColor(), 5)
+            nextMoves = this.getMoves(this.getPlayingColor(), 5, ignoreCheck)
         }
 
         if (this.configuration.isFinished) {
@@ -897,7 +897,7 @@ export default class Board {
         return { score: bestScore, max: false }
     }
 
-    calculateScoreByPiecesLocation(player = this.getPlayingColor()) {
+    calculateScoreByPiecesLocation (player = this.getPlayingColor()) {
         const columnMapping = { A: 0, B: 1, C: 2, D: 3, E: 4, F: 5, G: 6, H: 7 }
         const scoreMultiplier = 0.5
         let score = 0
@@ -911,7 +911,7 @@ export default class Board {
         return score
     }
 
-    calculateScore(playerColor = this.getPlayingColor()) {
+    calculateScore (playerColor = this.getPlayingColor()) {
         let scoreIndex = 0
 
         if (this.configuration.checkMate) {

--- a/lib/js-chess-engine.mjs
+++ b/lib/js-chess-engine.mjs
@@ -2,11 +2,11 @@ import Board from './Board.mjs'
 import { printToConsole, getFEN } from './utils.mjs'
 
 export class Game {
-    constructor(configuration) {
+    constructor (configuration) {
         this.board = new Board(configuration)
     }
 
-    move(from, to) {
+    move (from, to) {
         from = from.toUpperCase()
         to = to.toUpperCase()
         const possibleMoves = this.board.getMoves()
@@ -18,42 +18,42 @@ export class Game {
         return { [from]: to }
     }
 
-    moves(from = null, ignoreCheckValidation = false) {
+    moves (from = null, ignoreCheckValidation = false) {
         const allMoves = this.board.getMoves(this.board.getPlayingColor(), null, ignoreCheckValidation)
         return (from ? allMoves[from.toUpperCase()] : allMoves) || []
     }
 
-    setPiece(location, piece) {
+    setPiece (location, piece) {
         this.board.setPiece(location, piece)
     }
 
-    removePiece(location) {
+    removePiece (location) {
         this.board.removePiece(location)
     }
 
-    aiMove(level = 2, ignoreCheckValidation = false) {
+    aiMove (level = 2, ignoreCheckValidation = false) {
         const move = this.board.calculateAiMove(level, ignoreCheckValidation)
         return this.move(move.from, move.to)
     }
 
-    getHistory(reversed = false) {
+    getHistory (reversed = false) {
         return reversed ? this.board.history.reverse() : this.board.history
     }
 
-    printToConsole() {
+    printToConsole () {
         printToConsole(this.board.configuration)
     }
 
-    exportJson() {
+    exportJson () {
         return this.board.exportJson()
     }
 
-    exportFEN() {
+    exportFEN () {
         return getFEN(this.board.configuration)
     }
 }
 
-export function moves(config, ignoreCheckValidation = false) {
+export function moves (config, ignoreCheckValidation = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
@@ -61,7 +61,7 @@ export function moves(config, ignoreCheckValidation = false) {
     return game.moves()
 }
 
-export function status(config) {
+export function status (config) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
@@ -69,7 +69,7 @@ export function status(config) {
     return game.exportJson()
 }
 
-export function getFen(config) {
+export function getFen (config) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
@@ -77,7 +77,7 @@ export function getFen(config) {
     return game.exportFEN()
 }
 
-export function move(config, from, to, ignoreCheckValidation = false) {
+export function move (config, from, to, ignoreCheckValidation = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
@@ -90,7 +90,7 @@ export function move(config, from, to, ignoreCheckValidation = false) {
     }
 }
 
-export function aiMove(config, level = 2, ignoreCheckValidation = false) {
+export function aiMove (config, level = 2, ignoreCheckValidation = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }

--- a/lib/js-chess-engine.mjs
+++ b/lib/js-chess-engine.mjs
@@ -2,11 +2,11 @@ import Board from './Board.mjs'
 import { printToConsole, getFEN } from './utils.mjs'
 
 export class Game {
-    constructor (configuration) {
+    constructor(configuration) {
         this.board = new Board(configuration)
     }
 
-    move (from, to) {
+    move(from, to) {
         from = from.toUpperCase()
         to = to.toUpperCase()
         const possibleMoves = this.board.getMoves()
@@ -18,42 +18,42 @@ export class Game {
         return { [from]: to }
     }
 
-    moves (from = null, ignoreCheck = false) {
-        const allMoves = this.board.getMoves(this.board.getPlayingColor(), null, ignoreCheck)
+    moves(from = null, ignoreCheckValidation = false) {
+        const allMoves = this.board.getMoves(this.board.getPlayingColor(), null, ignoreCheckValidation)
         return (from ? allMoves[from.toUpperCase()] : allMoves) || []
     }
 
-    setPiece (location, piece) {
+    setPiece(location, piece) {
         this.board.setPiece(location, piece)
     }
 
-    removePiece (location) {
+    removePiece(location) {
         this.board.removePiece(location)
     }
 
-    aiMove (level = 2, ignoreCheck = false) {
-        const move = this.board.calculateAiMove(level, ignoreCheck)
+    aiMove(level = 2, ignoreCheckValidation = false) {
+        const move = this.board.calculateAiMove(level, ignoreCheckValidation)
         return this.move(move.from, move.to)
     }
 
-    getHistory (reversed = false) {
+    getHistory(reversed = false) {
         return reversed ? this.board.history.reverse() : this.board.history
     }
 
-    printToConsole () {
+    printToConsole() {
         printToConsole(this.board.configuration)
     }
 
-    exportJson () {
+    exportJson() {
         return this.board.exportJson()
     }
 
-    exportFEN () {
+    exportFEN() {
         return getFEN(this.board.configuration)
     }
 }
 
-export function moves (config, ignoreCheck = false) {
+export function moves(config, ignoreCheckValidation = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
@@ -61,7 +61,7 @@ export function moves (config, ignoreCheck = false) {
     return game.moves()
 }
 
-export function status (config) {
+export function status(config) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
@@ -69,7 +69,7 @@ export function status (config) {
     return game.exportJson()
 }
 
-export function getFen (config) {
+export function getFen(config) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
@@ -77,11 +77,11 @@ export function getFen (config) {
     return game.exportFEN()
 }
 
-export function move (config, from, to, ignoreCheck = false) {
+export function move(config, from, to, ignoreCheckValidation = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
-    const game = new Game(config, ignoreCheck)
+    const game = new Game(config, ignoreCheckValidation)
     game.move(from, to)
     if (typeof config === 'object') {
         return game.exportJson()
@@ -90,11 +90,11 @@ export function move (config, from, to, ignoreCheck = false) {
     }
 }
 
-export function aiMove (config, level = 2, ignoreCheck = false) {
+export function aiMove(config, level = 2, ignoreCheckValidation = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
     const game = new Game(config)
-    const move = game.board.calculateAiMove(level, ignoreCheck)
+    const move = game.board.calculateAiMove(level, ignoreCheckValidation)
     return { [move.from]: move.to }
 }

--- a/lib/js-chess-engine.mjs
+++ b/lib/js-chess-engine.mjs
@@ -31,8 +31,8 @@ export class Game {
         this.board.removePiece(location)
     }
 
-    aiMove (level = 2) {
-        const move = this.board.calculateAiMove(level)
+    aiMove (level = 2, ignoreCheck = false) {
+        const move = this.board.calculateAiMove(level, ignoreCheck)
         return this.move(move.from, move.to)
     }
 
@@ -90,11 +90,11 @@ export function move (config, from, to, ignoreCheck = false) {
     }
 }
 
-export function aiMove (config, level = 2) {
+export function aiMove (config, level = 2, ignoreCheck = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
     const game = new Game(config)
-    const move = game.board.calculateAiMove(level)
+    const move = game.board.calculateAiMove(level, ignoreCheck)
     return { [move.from]: move.to }
 }

--- a/lib/js-chess-engine.mjs
+++ b/lib/js-chess-engine.mjs
@@ -18,8 +18,9 @@ export class Game {
         return { [from]: to }
     }
 
-    moves (from = null) {
-        return (from ? this.board.getMoves()[from.toUpperCase()] : this.board.getMoves()) || []
+    moves (from = null, ignoreCheck = false) {
+        const allMoves = this.board.getMoves(this.board.getPlayingColor(), null, ignoreCheck)
+        return (from ? allMoves[from.toUpperCase()] : allMoves) || []
     }
 
     setPiece (location, piece) {
@@ -52,7 +53,7 @@ export class Game {
     }
 }
 
-export function moves (config) {
+export function moves (config, ignoreCheck = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
@@ -76,11 +77,11 @@ export function getFen (config) {
     return game.exportFEN()
 }
 
-export function move (config, from, to) {
+export function move (config, from, to, ignoreCheck = false) {
     if (!config) {
         throw new Error('Configuration param required.')
     }
-    const game = new Game(config)
+    const game = new Game(config, ignoreCheck)
     game.move(from, to)
     if (typeof config === 'object') {
         return game.exportJson()

--- a/lib/js-chess-engine.mjs
+++ b/lib/js-chess-engine.mjs
@@ -6,15 +6,15 @@ export class Game {
         this.board = new Board(configuration)
     }
 
-    move (from, to) {
+    move (from, to, ignoreCheckValidation = false) {
         from = from.toUpperCase()
         to = to.toUpperCase()
-        const possibleMoves = this.board.getMoves()
+        const possibleMoves = this.board.getMoves(undefined, undefined, ignoreCheckValidation)
         if (!possibleMoves[from] || !possibleMoves[from].includes(to)) {
             throw new Error(`Invalid move from ${from} to ${to} for ${this.board.getPlayingColor()}`)
         }
         this.board.addMoveToHistory(from, to)
-        this.board.move(from, to)
+        this.board.move(from, to, ignoreCheckValidation)
         return { [from]: to }
     }
 
@@ -33,7 +33,7 @@ export class Game {
 
     aiMove (level = 2, ignoreCheckValidation = false) {
         const move = this.board.calculateAiMove(level, ignoreCheckValidation)
-        return this.move(move.from, move.to)
+        return this.move(move.from, move.to, ignoreCheckValidation)
     }
 
     getHistory (reversed = false) {


### PR DESCRIPTION
This pull request introduces the `ignoreCheckValidation` parameter across several methods in the `Board` and `Game` classes, as well as related functions in `lib/js-chess-engine.mjs`. This parameter allows bypassing the validation of moves that would place the king in check, enabling more flexible game logic, such as testing hypothetical moves or configurations.

### Changes to `Board` class:

* Added `ignoreCheckValidation` parameter to `getMoves`, allowing moves to bypass check validation logic. [[1]](diffhunk://#diff-e72a48c64457d6907f4e3c228b455f39bd0d709d1478537a264ac4b75a78a789L261-R261) [[2]](diffhunk://#diff-e72a48c64457d6907f4e3c228b455f39bd0d709d1478537a264ac4b75a78a789R297)
* Updated `calculateAiMove` and `calculateAiMoves` to accept `ignoreCheckValidation`, ensuring AI move calculations can bypass check validation when needed. [[1]](diffhunk://#diff-e72a48c64457d6907f4e3c228b455f39bd0d709d1478537a264ac4b75a78a789L790-R796) [[2]](diffhunk://#diff-e72a48c64457d6907f4e3c228b455f39bd0d709d1478537a264ac4b75a78a789L805-R806)
* Modified `testMoveScores` to include the `ignoreCheckValidation` parameter, enabling deeper AI move testing without check validation.

### Changes to `Game` class:

* Added `ignoreCheckValidation` parameter to `move` and `moves` methods, permitting moves to bypass check validation.
* Updated `aiMove` to include `ignoreCheckValidation`, allowing AI moves to bypass check validation logic.

### Changes to exported functions in `lib/js-chess-engine.mjs`:

* Added `ignoreCheckValidation` parameter to `moves`, `move`, and `aiMove` functions, extending the functionality to external calls. [[1]](diffhunk://#diff-67770aac4ffb6766c08b20b315afc2252161e4ea1afa004f6bda5260246feb9fL55-R56) [[2]](diffhunk://#diff-67770aac4ffb6766c08b20b315afc2252161e4ea1afa004f6bda5260246feb9fL79-R84) [[3]](diffhunk://#diff-67770aac4ffb6766c08b20b315afc2252161e4ea1afa004f6bda5260246feb9fL92-R98)